### PR TITLE
change SDXL step node minimum preconditioning int to 0, 1 forces N-1 steps for base when used as start step.

### DIFF
--- a/wlsh_nodes.py
+++ b/wlsh_nodes.py
@@ -230,7 +230,7 @@ class WLSH_SDXL_Steps:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "precondition": ("INT", {"default": 3, "min": 1, "max": 10000}),
+                "precondition": ("INT", {"default": 3, "min": 0, "max": 10000}),
                 "base": ("INT", {"default": 12, "min": 1, "max": 10000}),
                 "total": ("INT", {"default": 20, "min": 1, "max": 10000}),
             }


### PR DESCRIPTION
When using the SDXL step nodes, it enforces a 1 minimum for the pre integer.  0 is a valid choice and should be allowed.  It forces steps when no refiner is being used to N-1,  25 steps will only run 24 steps and so on.  I do not believe this to be intended behaviour. 